### PR TITLE
[Feature] Added limit of characters

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -209,6 +209,13 @@ export default {
 
     .card {
       height: 100%;
+      /deep/ .description {
+        height: 72px;
+        overflow: hidden;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        display: -webkit-box;
+      }
     }
   }
 }


### PR DESCRIPTION
Adicionado limite de caracteres nas descrições das aulas, dentro da página inicial da trilha. Ao acessar a página da aula, a descrição continuará sendo exibida por completo.

<img width="931" alt="texto-cortado" src="https://user-images.githubusercontent.com/54125469/221956257-1f7e0b48-509b-4598-acf5-b5ce3131c80f.png">
